### PR TITLE
Fix how Node.js and browser WASM is exposed to library users

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "vector-merkle-tree",
+  "version": "0.1.0",
+  "main": "node/index.js",
+  "browser": "browser/index.js"
+}


### PR DESCRIPTION
After this, I'm no longer running into module loading issues. Instead, I get this with `merkle-wasm` though:

```bash
node ./index.js
Creating tree
Creating leaves
Inserting leaves
/Users/jannis/work/connext/merkle-wasm/node_modules/vector-merkle-tree/node/index.js:166
    throw new Error(getStringFromWasm0(arg0, arg1));
    ^

Error: null pointer passed to rust
    at module.exports.__wbindgen_throw (/Users/jannis/work/connext/merkle-wasm/node_modules/vector-merkle-tree/node/index.js:166:11)
    at wasm-function[112]:0x6ac1
    at wasm-function[110]:0x6aa9
    at wasm-function[38]:0x5868
    at Tree.insert_hex_js (/Users/jannis/work/connext/merkle-wasm/node_modules/vector-merkle-tree/node/index.js:140:14)
    at /Users/jannis/work/connext/merkle-wasm/index.js:19:10
    at Array.forEach (<anonymous>)
    at run (/Users/jannis/work/connext/merkle-wasm/index.js:18:10)
    at Object.<anonymous> (/Users/jannis/work/connext/merkle-wasm/index.js:24:1)
    at Module._compile (internal/modules/cjs/loader.js:1133:30)
```