### PR TITLE
Correctly declare the tree constructor for JS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub struct Tree {
 
 #[wasm_bindgen]
 impl Tree {
+    #[wasm_bindgen(constructor)]
     pub fn new() -> Self {
         Self { leaves: Vec::new() }
     }


### PR DESCRIPTION
Without this, calling `new Tree()` does not properly initialize the tree.

With this, I could finally run the `merkle-wasm` example code without errors:
```js
➜  merkle-wasm git:(main) ✗ node ./index.js
Creating tree
Creating leaves
Inserting leaves
Root 0xa1fe58e7760abb9d1dff79945906cfe3be86467a88424f13e9087e82ea2b786b
```